### PR TITLE
Rescale y lims by guild to the max value of the time series

### DIFF
--- a/R/plot_mass_inshore_survey.R
+++ b/R/plot_mass_inshore_survey.R
@@ -49,93 +49,77 @@ plot_mass_inshore_survey <- function(shadedRegion = NULL,
                                        "Planktivore Spring", "Planktivore Fall",
                                        "Benthos Spring", "Benthos Fall"))
 
+  # Determine the order of your facets
+  facet_order <- levels(fix$Var)
 
-  ymax <- fix |>
-    tidyr::separate(Var, into = c("vars","Trash"),sep=" ") |>
-    dplyr::group_by(vars) |>
-    dplyr::summarise(max = max(Index,na.rm=T))
+  # function to plot custom y lims as scalar multiplier of 1.2x the max value for guild
+  plot_custom_lims <- function(data) {
+    new_max <- max((data$Index) * 1.2, na.rm = TRUE)
+    p <- data |>
+      ggplot2::ggplot(ggplot2::aes(x = Time, y = Index)) +
+      ggplot2::annotate(
+        "rect",
+        fill = setup$shade.fill,
+        alpha = setup$shade.alpha,
+        xmin = setup$x.shade.min,
+        xmax = setup$x.shade.max,
+        ymin = -Inf,
+        ymax = Inf
+      ) +
+      ggplot2::geom_point() +
+      ggplot2::geom_line() +
+      ggplot2::geom_hline(
+        ggplot2::aes(yintercept = hline, group = Var)
+      ) +
+      ggplot2::geom_ribbon(
+        # data = fix,
+        ggplot2::aes(x = Time, ymin = lower, ymax = upper),
+        alpha = 0.5,
+        fill = "gray"
+      ) +
+      #  ggplot2::ggtitle("Massachusetts inshore BTS") +
+      ggplot2::ylab(ggplot2::element_blank()) +
+      ggplot2::xlab(ggplot2::element_blank()) +
+      ggplot2::scale_y_continuous(
+        limits = c(0, new_max),
+        oob = scales::oob_keep
+      ) +
+      ggplot2::coord_cartesian(clip = "on") +
+      ggplot2::facet_wrap(~Var, ncol = 2) +
+      ecodata::geom_gls() +
+      ecodata::geom_lm(n = 10) +
+      ecodata::theme_ts() +
+      ecodata::theme_facet() +
+      ecodata::theme_title()
+  }
 
-  usevars <- fix |>
-    dplyr::distinct(Var) |>
-    dplyr::pull()
+  p1 <-  fix |>
+    dplyr::filter(Var == "Piscivore Spring" | Var == "Piscivore Fall") |>
+    plot_custom_lims()
 
-  df2 <- data.frame(Time = 2015,Var = usevars) |>
-    dplyr::mutate(vars = stringr::word(Var)) |>
-    dplyr::left_join(ymax,by="vars") |>
-    dplyr::select(-vars)
+  p2 <- fix |>
+    dplyr::filter(Var == "Benthivore Spring" | Var == "Benthivore Fall") |>
+    plot_custom_lims()
 
-  # Old code
-  #fix <- ecodata::mass_inshore_survey |>
-  #   dplyr::filter(EPU %in% filterEPUs,
-  #                 grepl("Index",Var),
-  #                 !grepl("Other",Var)) |>
-  #   tidyr::separate(Var,into = c("Var","Trash"),sep =" Biomass") |>
-  #   dplyr::select(-Trash) |>
-  #   dplyr::mutate(Var = as.factor(Var))  |>
-  #   dplyr::group_by(Var) |>
-  #   dplyr::mutate(hline = mean(Value))
+  p3 <- fix |>
+    dplyr::filter(Var == "Planktivore Spring" | Var == "Planktivore Fall") |>
+    plot_custom_lims()
 
-  #fix$Var <- factor(fix$Var,levels =  c("Piscivore Spring","Piscivore Fall",
-  #                                       "Benthivore Spring","Benthivore Fall",
-  #                                       "Planktivore Spring","Planktivore Fall",
-  #                                       "Benthos Spring","Benthos Fall"))
+  p4 <- fix |>
+    dplyr::filter(Var == "Benthos Spring" | Var == "Benthos Fall") |>
+    plot_custom_lims()
 
+  p <- ggpubr::ggarrange(p1, p2, p3, p4, ncol = 1, nrow = 4)
 
-  # ymax <- fix |>
-  #   tidyr::separate(Var, into = c("vars","Trash"),sep=" ") |>
-  #   dplyr::group_by(vars) |>
-  #   dplyr::summarise(max = max(Value,na.rm=T))
-
-  #usevars <- fix |>
-  #  dplyr::distinct(Var) |>
-  #  dplyr::pull()
-
-  #df2 <- data.frame(Time = 2015,Var = usevars) |>
-  #  dplyr::mutate(vars = stringr::word(Var)) |>
-  #  dplyr::left_join(ymax,by="vars") |>
-  #  dplyr::select(-vars)
-
-  # code for generating plot object p
-  # ensure that setup list objects are called as setup$...
-  # e.g. fill = setup$shade.fill, alpha = setup$shade.alpha,
-  # xmin = setup$x.shade.min , xmax = setup$x.shade.max
-  #
-  p <- fix |>
-    ggplot2::ggplot(ggplot2::aes(x = Time, y = Index))+
-    ggplot2::annotate("rect", fill = setup$shade.fill, alpha = setup$shade.alpha,
-        xmin = setup$x.shade.min , xmax = setup$x.shade.max,
-        ymin = -Inf, ymax = Inf) +
-    ggplot2::geom_point()+
-    ggplot2::geom_line()+
-    ggplot2::geom_point(data = df2,ggplot2::aes(x=Time,y=max),alpha = 0)+
-    ggplot2::geom_hline(ggplot2::aes(yintercept = hline,
-                                     group = Var),
-                        linewidth = setup$hline.size,
-                        alpha = setup$hline.alpha,
-                        linetype = setup$hline.lty)+
-    ggplot2::geom_ribbon(data = fix,
-                         ggplot2::aes(x = Time, ymin = pmax(lower,0), ymax = upper),
-                         alpha = 0.5,
-                         fill = "gray")+
-    ggplot2::ggtitle("Massachusetts inshore BTS")+
-    ggplot2::ylab(expression("Biomass (kg tow"^-1*")"))+
-    ggplot2::xlab(ggplot2::element_blank())+
-    ggplot2::facet_wrap(~Var,ncol=2,scales = "free_y")+
-    ecodata::geom_gls()+
-    ecodata::geom_lm(n=n)+
-    ecodata::theme_ts()+
-    ecodata::theme_facet()+
-    ecodata::theme_title()
-
-   # optional code for New England specific (2 panel) formatting
-    # if (report == "NewEngland") {
-    #   p <- p +
-    #     ggplot2::theme(legend.position = "bottom",
-    #                    legend.title = ggplot2::element_blank())
-    #
-    # }
+  p <- ggpubr::annotate_figure(
+    p,
+    top = ggpubr::text_grob("Massachusetts inshore BTS", size = 12),
+    left = ggpubr::text_grob("Biomass (kg tow ^-1)", rot = 90, size = 16)
+  )
 
     return(p)
 }
 
 attr(plot_mass_inshore_survey,"report") <- c("MidAtlantic","NewEngland")
+
+#plot_mass_inshore_survey(report = "NewEngland")

--- a/R/plot_mass_inshore_survey.R
+++ b/R/plot_mass_inshore_survey.R
@@ -87,7 +87,7 @@ plot_mass_inshore_survey <- function(shadedRegion = NULL,
       ggplot2::coord_cartesian(clip = "on") +
       ggplot2::facet_wrap(~Var, ncol = 2) +
       ecodata::geom_gls() +
-      ecodata::geom_lm(n = 10) +
+      ecodata::geom_lm(n = n) +
       ecodata::theme_ts() +
       ecodata::theme_facet() +
       ecodata::theme_title()


### PR DESCRIPTION
Similar underlying issue as the aggregate biomass plots where the y axis was scaled to the error region rather than the time series.

Updates to plot_mass_inshore_survey.R:

- Removes previous code to set ymax, replaced with a function on line 56 (plot_custom_lims) that sets new_max = 1.2x the max value of the Index for each guild (same scalar value as I did in plot_aggregate_biomass)
- Facets by guild with ggplot2::coord_cartesian(clip = "on") to stop the plot from including shaded error region beyond the designated ymax
- Plots p1 - p4 by guild and then combines with ggarrage 