### PR TITLE
Add missing mean trend lines to spring NEAMAP plots

### DIFF
--- a/R/plot_mab_inshore_survey.R
+++ b/R/plot_mab_inshore_survey.R
@@ -36,7 +36,7 @@ plot_mab_inshore_survey <- function(shadedRegion = NULL,
     dplyr::mutate(Value = as.numeric(Value),
                   CV = as.numeric(CV)) |>
     dplyr::group_by(Var) |>
-    dplyr::mutate(hline = mean(Value),
+    dplyr::mutate(hline = mean(Value, na.rm = TRUE),
                   SD = Value * CV, #calculate SD from CV
                   upper = Value + (2*SD),
                   lower = Value - (2*SD))
@@ -122,3 +122,4 @@ plot_mab_inshore_survey <- function(shadedRegion = NULL,
 }
 
 attr(plot_mab_inshore_survey,"report") <- c("MidAtlantic","NewEngland")
+


### PR DESCRIPTION
In plot_mab_inshore_survey.R:

- Line 39: added na.rm = TRUE to the mean calculation for hline. This allows for the dashed trend lines that were missing from the Spring plots due to missing years. 