### PR TITLE
aesthetic changes in plot_benthos_index.R to plot trend lines on top of time series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ inst/doc
 .Ruserdata
 .DS_Store
 ecodata.Rproj
+plot_forage_index.R
 
 # folders
 docs

--- a/R/plot_benthos_index.R
+++ b/R/plot_benthos_index.R
@@ -69,8 +69,8 @@ plot_benthos_index <- function(shadedRegion = NULL,
                         xmin = setup$x.shade.min , xmax = setup$x.shade.max,
                         ymin = -Inf, ymax = Inf) +
       ggplot2::geom_ribbon(ggplot2::aes(ymin = Lower, ymax = Upper, fill = Season), alpha = 0.5)+
-      ggplot2::geom_point()+
-      ggplot2::geom_line()+
+      ggplot2::geom_point(ggplot2::aes(color = .data$Season)) +
+      ggplot2::geom_line(ggplot2::aes(color = .data$Season)) +
       ggplot2::ggtitle("")+
       ggplot2::ylab(paste("Relative",varName,"Biomass"))+
       ggplot2::xlab(ggplot2::element_blank())+

--- a/R/plot_benthos_index.R
+++ b/R/plot_benthos_index.R
@@ -69,8 +69,8 @@ plot_benthos_index <- function(shadedRegion = NULL,
                         xmin = setup$x.shade.min , xmax = setup$x.shade.max,
                         ymin = -Inf, ymax = Inf) +
       ggplot2::geom_ribbon(ggplot2::aes(ymin = Lower, ymax = Upper, fill = Season), alpha = 0.5)+
-      ggplot2::geom_point(ggplot2::aes(color = .data$Season)) +
-      ggplot2::geom_line(ggplot2::aes(color = .data$Season)) +
+      ggplot2::geom_point() +
+      ggplot2::geom_line() +
       ggplot2::ggtitle("")+
       ggplot2::ylab(paste("Relative",varName,"Biomass"))+
       ggplot2::xlab(ggplot2::element_blank())+


### PR DESCRIPTION
Previous aesthetic changes to plotting code made in READ-EDAB-SOE_reports/create_plots_slides.R overrode trend lines. Moving these changes into ecodata so that the trend lines are added after the plot aesthetics.

plot_benthos_index.R lines 72-73:
- colored time series points and lines to match shaded fall and spring colors (red/blue)

New figures with better visualization of trend lines here:
NE: https://github.com/NEFSC/READ-EDAB-SOE_reports/blob/stephanie_dev/images/NewEngland/slide_benthos_NewEngland_2026-01-16.png

MID: https://github.com/NEFSC/READ-EDAB-SOE_reports/blob/stephanie_dev/images/MidAtlantic/slide_benthos_MidAtlantic_2026-01-16.png