### PR TITLE
aesthetic changes in zooplankton_anomaly to plot points behind trend lines.

### DIFF
--- a/R/plot_zooplankton_index.R
+++ b/R/plot_zooplankton_index.R
@@ -68,8 +68,8 @@ plot_zooplankton_index <- function(shadedRegion = NULL,
                         xmin = setup$x.shade.min , xmax = setup$x.shade.max,
                         ymin = -Inf, ymax = Inf) +
       ggplot2::geom_ribbon(ggplot2::aes(ymin = Lower, ymax = Upper, fill = Season), alpha = 0.5)+
-      ggplot2::geom_point(ggplot2::aes(color = .data$Season)) +
-      ggplot2::geom_line(ggplot2::aes(color = .data$Season)) +
+      ggplot2::geom_point() +
+      ggplot2::geom_line() +
       ggplot2::theme(strip.text.x = ggplot2::element_blank(),
                      plot.background = ggplot2::element_rect(fill = "white")) +
       ggplot2::ggtitle("")+

--- a/R/plot_zooplankton_index.R
+++ b/R/plot_zooplankton_index.R
@@ -68,8 +68,10 @@ plot_zooplankton_index <- function(shadedRegion = NULL,
                         xmin = setup$x.shade.min , xmax = setup$x.shade.max,
                         ymin = -Inf, ymax = Inf) +
       ggplot2::geom_ribbon(ggplot2::aes(ymin = Lower, ymax = Upper, fill = Season), alpha = 0.5)+
-      ggplot2::geom_point()+
-      ggplot2::geom_line()+
+      ggplot2::geom_point(ggplot2::aes(color = .data$Season)) +
+      ggplot2::geom_line(ggplot2::aes(color = .data$Season)) +
+      ggplot2::theme(strip.text.x = ggplot2::element_blank(),
+                     plot.background = ggplot2::element_rect(fill = "white")) +
       ggplot2::ggtitle("")+
       ggplot2::ylab(paste("Relative",varName,"Biomass"))+
       ggplot2::xlab(ggplot2::element_blank())+

--- a/R/plot_zooplankton_index.R
+++ b/R/plot_zooplankton_index.R
@@ -68,8 +68,8 @@ plot_zooplankton_index <- function(shadedRegion = NULL,
                         xmin = setup$x.shade.min , xmax = setup$x.shade.max,
                         ymin = -Inf, ymax = Inf) +
       ggplot2::geom_ribbon(ggplot2::aes(ymin = Lower, ymax = Upper, fill = Season), alpha = 0.5)+
-      ggplot2::geom_point(ggplot2::aes(color = .data$Season)) +
-      ggplot2::geom_line(ggplot2::aes(color = .data$Season)) +
+      ggplot2::geom_point() +
+      ggplot2::geom_line() +
       ggplot2::theme(strip.text.x = ggplot2::element_blank(),
                      plot.background = ggplot2::element_rect(fill = "white")) +
       ggplot2::ggtitle("")+
@@ -117,7 +117,12 @@ plot_zooplankton_index <- function(shadedRegion = NULL,
       ggplot2::ggtitle("")+
       ggplot2::ylab(paste(varName,"Center of Gravity, km"))+
       ggplot2::xlab(ggplot2::element_blank())+
-      ggplot2::facet_wrap(~Direction, scales = "free_y")+ #Season
+      ggplot2::theme(legend.position = 'bottom') +
+      ggplot2::facet_grid(
+        cols = ggplot2::vars(Season),
+        rows = ggplot2::vars(Direction),
+        scales = "free_y"
+      ) +
       ecodata::geom_gls()+
       ecodata::geom_lm(n=n)+
       ecodata::theme_ts()+


### PR DESCRIPTION
Previous aesthetic changes to plotting code made in READ-EDAB-SOE_reports/create_plots_slides.R overrode trend lines. Moving these changes into ecodata so that the trend lines are added after the plot aesthetics.

In plot_zooplankton_index.R (lines 71-74):
- Match colors of time series points and lines to shaded area surrounding time series (red/blue)
- Remove extra facet labels on x axis
- Set background of plot area to white.

New plots here:
NE: https://github.com/NEFSC/READ-EDAB-SOE_reports/blob/stephanie_dev/images/NewEngland/slide_zooplankton_anomaly_NewEngland_2026-01-16.png

MAB: https://github.com/NEFSC/READ-EDAB-SOE_reports/blob/stephanie_dev/images/MidAtlantic/slide_zooplankton_anomaly_MidAtlantic_2026-01-16.png