### PR TITLE
aesthetic changes in forage shifts to plot behind trend lines

### DIFF
--- a/R/plot_forage_index.R
+++ b/R/plot_forage_index.R
@@ -102,12 +102,18 @@ plot_forage_index <- function(shadedRegion = NULL,
                         xmin = setup$x.shade.min , xmax = setup$x.shade.max,
                         ymin = -Inf, ymax = Inf) +
       ggplot2::geom_ribbon(ggplot2::aes(ymin = Lower, ymax = Upper, fill = Season), alpha = 0.3)+ #
-      ggplot2::geom_point()+
-      ggplot2::geom_line()+
-      ggplot2::ggtitle("")+
-      ggplot2::ylab(expression("Forage Center of Gravity, km"))+
+      ggplot2::geom_point(ggplot2::aes(color = .data$Season)) +
+      ggplot2::geom_line(ggplot2::aes(color = .data$Season)) +
+      ggplot2::ggtitle("Northeast U.S. Forage Fish Distribution") +
+      ggplot2::ylab("Center of Gravity, km")+
       ggplot2::xlab(ggplot2::element_blank())+
-      ggplot2::facet_wrap(~Direction, scales = "free_y")+ #Season
+      ggplot2::facet_wrap(~Var, nrow = 2) +
+      ggplot2::theme(legend.position = "bottom") +
+      ggplot2::facet_grid(
+        cols = ggplot2::vars(Season),
+        rows = ggplot2::vars(Direction),
+        scales = "free_y"
+      ) +
       ecodata::geom_gls()+
       ecodata::geom_lm(n=n)+
       ecodata::theme_ts()+

--- a/R/plot_forage_index.R
+++ b/R/plot_forage_index.R
@@ -102,8 +102,8 @@ plot_forage_index <- function(shadedRegion = NULL,
                         xmin = setup$x.shade.min , xmax = setup$x.shade.max,
                         ymin = -Inf, ymax = Inf) +
       ggplot2::geom_ribbon(ggplot2::aes(ymin = Lower, ymax = Upper, fill = Season), alpha = 0.3)+ #
-      ggplot2::geom_point(ggplot2::aes(color = .data$Season)) +
-      ggplot2::geom_line(ggplot2::aes(color = .data$Season)) +
+      ggplot2::geom_point() +
+      ggplot2::geom_line() +
       ggplot2::ggtitle("Northeast U.S. Forage Fish Distribution") +
       ggplot2::ylab("Center of Gravity, km")+
       ggplot2::xlab(ggplot2::element_blank())+


### PR DESCRIPTION
Previous aesthetic changes to plotting code made in READ-EDAB-SOE_reports/create_plots_slides.R overrode trend lines. Moving these changes into ecodata so that the trend lines are added after the plot aesthetics.

In plot_forage_index.R (lines 105 - 116):
- Match color of time series to shaded area (red/blue)
- Text for title and y axis
- Adjust faceting
- Move legend to bottom

New figure here with better visualization of trend lines: https://github.com/NEFSC/READ-EDAB-SOE_reports/blob/stephanie_dev/images/BothReports/slide_forage_dist_BothReports_2026-01-16.png