### PR TITLE
Add dashed mean lines to transition dates plots

### DIFF
--- a/R/plot_trans_dates.R
+++ b/R/plot_trans_dates.R
@@ -112,7 +112,8 @@ plot_trans_dates <- function(shadedRegion = NULL,
       ecodata::theme_facet()
 
     if (report == "NewEngland") {
-      p <- p + ggplot2::facet_wrap(~EPU, nrow = 2)
+      p <- p + ggplot2::facet_wrap(~EPU, nrow = 2) +
+        ggplot2::theme(strip.text.x = ggplot2::element_text(size = 10))
     } else {
       p <- p
     }

--- a/R/plot_trans_dates.R
+++ b/R/plot_trans_dates.R
@@ -62,6 +62,14 @@ plot_trans_dates <- function(shadedRegion = NULL,
       dplyr::filter(EPU %in% filterEPUs,
                     Var == "sumlen",
                     !Value == "NA")
+    mn <- fix |>
+      dplyr::group_by(EPU,Var) |>
+      dplyr::summarise(mn = mean(Value,na.rm = T),
+                       .groups="drop")
+
+    fix <- fix |>
+      dplyr::left_join(mn,by=c("Var","EPU"))
+
     p <- fix |>
       #dplyr::filter(Var %in% season) %>%
       ggplot2::ggplot(ggplot2::aes(x= Time, y = Value))+
@@ -72,6 +80,10 @@ plot_trans_dates <- function(shadedRegion = NULL,
       ggplot2::geom_line()+
       ecodata::geom_gls() +
       ecodata::geom_lm(n=n)+
+      ggplot2::geom_hline(ggplot2::aes(yintercept = mn),
+                          linewidth = setup$hline.size,
+                          alpha = setup$hline.alpha,
+                          linetype = setup$hline.lty)+
       # ggplot2::theme(strip.text=ggplot2::element_text(hjust=0),
       #                plot.title = ggplot2::element_text(size = 12))+
       ecodata::theme_title()+

--- a/R/plot_trans_dates.R
+++ b/R/plot_trans_dates.R
@@ -38,6 +38,14 @@ plot_trans_dates <- function(shadedRegion = NULL,
                                  "sprtrans" = "Spring",
                                  "maxday" = "Max"))
 
+    mn <- fix |>
+      dplyr::group_by(EPU,Var) |>
+      dplyr::summarise(mn = mean(Value,na.rm = T),
+                       .groups="drop")
+
+    fix <- fix |>
+      dplyr::left_join(mn,by=c("Var","EPU"))
+
     p <-  fix |>
 
       ggplot2::ggplot(ggplot2::aes(x= Time, y = Value, color = Var)) +
@@ -48,6 +56,10 @@ plot_trans_dates <- function(shadedRegion = NULL,
       ggplot2::geom_line() +
       ecodata::geom_gls() +
       ecodata::geom_lm(n=n)+
+      ggplot2::geom_hline(ggplot2::aes(yintercept = mn),
+                          linewidth = setup$hline.size,
+                          alpha = setup$hline.alpha,
+                          linetype = setup$hline.lty)+
       # ggplot2::theme(strip.text=ggplot2::element_text(hjust=0),
       #                plot.title = ggplot2::element_text(size = 12)) +
       ecodata::theme_title("") +
@@ -88,14 +100,22 @@ plot_trans_dates <- function(shadedRegion = NULL,
       #                plot.title = ggplot2::element_text(size = 12))+
       ecodata::theme_title()+
       ggplot2::ylab("Number of Days")+
-      ggplot2::ggtitle(paste0(report,": Number of days between spring and fall transition dates")) +
-      #ggplot2::xlab(ggplot2::element_blank())+
+      ggplot2::ggtitle(paste(
+        "Time between spring and fall transition in",
+        report
+      )) +
+      ggplot2::theme(
+        strip.background = ggplot2::element_blank(),
+        strip.text.x = ggplot2::element_blank()) +
       ecodata::theme_ts()+
       ggplot2::facet_wrap(.~EPU)+
       ecodata::theme_facet()
 
-
-
+    if (report == "NewEngland") {
+      p <- p + ggplot2::facet_wrap(~EPU, nrow = 2)
+    } else {
+      p <- p
+    }
 
 
   } else {


### PR DESCRIPTION
In plot_trans_dates.R, for varName == "length",

Lines 65-71:
- Groups the 'fix' dataframe by Var (sumlen) and EPU, then calculates the mean of the Value to create a dataframe called 'mn'
- Joins the 'mn' and 'fix' dataframes to create a new 'fix' 
- This was done using the same formatting as other SOE plots with a trend line (i.e. zooplankton diversity)

Lines 83-86:
- Adds horizontal trend line to ggplot using same code chunk as in other SOE plots with a mean trend line

New plots for MAB and NE: 
<img width="1950" height="750" alt="slide_transition_date_MidAtlantic_2026-01-20" src="https://github.com/user-attachments/assets/85255a23-8885-4edd-9d1f-fc182c5d2f42" />
<img width="1950" height="1500" alt="slide_transition_date_NewEngland_2026-01-20" src="https://github.com/user-attachments/assets/147e39de-0c41-43e6-b133-b619bffaa21c" />
