### PR TITLE
Remove billfishes and tuna from plot

### DIFF
--- a/R/plot_rec_hms.r
+++ b/R/plot_rec_hms.r
@@ -31,7 +31,8 @@ plot_rec_hms <- function(shadedRegion = NULL, report = "MidAtlantic", n = 0) {
     dplyr::mutate(Value = Value / 1000) |>
     dplyr::mutate(
       fac = dplyr::case_when(Group == "Scombridae" ~ "Tuna", TRUE ~ "Other")
-    )
+    ) |>
+    dplyr::filter(Group %in% c("LargeCoastal","SmallCoastal","Prohibited"))
 
   fix <- fix |>
     # merge in NA's to break lines

--- a/R/plot_rec_hms.r
+++ b/R/plot_rec_hms.r
@@ -32,6 +32,7 @@ plot_rec_hms <- function(shadedRegion = NULL, report = "MidAtlantic", n = 0) {
     dplyr::mutate(
       fac = dplyr::case_when(Group == "Scombridae" ~ "Tuna", TRUE ~ "Other")
     ) |>
+    # Exclude billfishes and tuna from plot, per HMS request - January 2026
     dplyr::filter(Group %in% c("LargeCoastal","SmallCoastal","Prohibited"))
 
   fix <- fix |>


### PR DESCRIPTION
Filtering out billfishes and tunas from rec_hms plot per suggestion from HMS group (while still remaining in the ecodata object). 

Plot now only shows Large Coastal, Small Coastal, and Prohibited
<img width="762" height="516" alt="mab" src="https://github.com/user-attachments/assets/317ef59d-e1eb-46ce-a987-08b9c659c938" />
<img width="762" height="516" alt="ne" src="https://github.com/user-attachments/assets/f1dd6bbf-afb7-442e-84d7-1dd8e6e3747a" />
