### PR TITLE
Commercial engagement plot legend and color palette

### DIFF
--- a/R/plot_engagement.R
+++ b/R/plot_engagement.R
@@ -75,14 +75,14 @@ plot_engagement <- function(shadedRegion = NULL,
                                             size = 0.2,
                                             linetype = 2))+
       ggplot2::scale_y_continuous(limits = c(0, 1)) +
-      ggplot2::scale_x_continuous(expand = ggplot2::expansion(mult = c(0.1, .2)),
-                         breaks = c(2007, 2010, 2015, 2020,2024))+
+      ggplot2::scale_x_continuous(breaks = c(2007, 2010, 2015, 2020,2024))+
       ggplot2::scale_alpha_discrete(range = c(0.15, 0.9)) +
-      ggplot2::scale_color_brewer(palette = "Paired")+
-      ggplot2::theme(legend.position = "none")+
-      ggrepel::geom_label_repel(ggplot2::aes(label = label),hjust=0,
-                       nudge_x = 1, xlim=c(2025,2028),
-                       na.rm = TRUE, max.overlaps = Inf)+
+      ggplot2::theme(
+        legend.position = "bottom",
+        legend.title = ggplot2::element_text(face = "bold"),
+        legend.box = "horizontal"
+      ) +
+      ggplot2::guides(color = ggplot2::guide_legend(nrow = 4)) +
       ggplot2::ggtitle(paste(setup$region, "Port Activity in Top", varName, "Fishing Communities"))
 
     # code for generating table of community social vulnerabilities


### PR DESCRIPTION
Some changes to the new commercial engagement plots that Bobby produced.

Old plot with town names on the side. Plot needs to be very wide and plot names overlap with each other and points:
<img width="2700" height="1200" alt="slide_commercial_engagement_NewEngland_2026-01-16" src="https://github.com/user-attachments/assets/753f6034-6e8b-4d9c-82b0-3dea5fc26bc1" />

In plot_engagement.R:
- Moved town names to a legend at the bottom of the plot
- Removed the color palette and used the default for geom_ (same color palette as abcacl and productivity anomaly)
- Removed the geom_label_repel that adds town names to the plot
- Removed expansion in scale_x_continuous that allowed for space on the right hand side of the plot to fit town names

New plots:
<img width="2100" height="1500" alt="commercial_engagement_NewEngland_2026-01-20" src="https://github.com/user-attachments/assets/5dfe4fa9-9409-494b-84ea-c342c8a04462" />
<img width="2100" height="1500" alt="commercial_engagement_MidAtlantic_2026-01-20" src="https://github.com/user-attachments/assets/66e5f213-4dc9-4e67-a03a-913881dff831" />

