### PR TITLE
Change plot behavior for annual chlorophyll and primary production (`plot_annual_chl_pp`)

### DIFF
--- a/R/plot_annual_chl_pp.R
+++ b/R/plot_annual_chl_pp.R
@@ -60,6 +60,13 @@ plot_annual_chl_pp <- function(shadedRegion = NULL,
 
   hline <- mean(fix$Value)
   varunits <- unique(fix$Units)
+
+  if (varName == "pp" & plottype == "total") {
+    fix <- dplyr::mutate(fix, Value = Value/1000000)
+    hline <- mean(fix$Value)
+    varunits <- "Carbon (million MT)"
+  }
+
   # code for generating plot object p
   # ensure that setup list objects are called as setup$...
   # e.g. fill = setup$shade.fill, alpha = setup$shade.alpha,

--- a/R/plot_chl_pp.R
+++ b/R/plot_chl_pp.R
@@ -5,6 +5,7 @@
 #'
 #' @param shadedRegion Numeric vector. Years denoting the shaded region of the plot (most recent 10)
 #' @param report Character string. Which SOE report ("MidAtlantic", "NewEngland")
+#' @param EPU Character string. Which EPU for New England report ("GB", "GOM") Mid will always be MAB
 #' @param varName Character string. Which Variable to plot ("chl","pp","size")
 #' @param plottype Character string. Which plot ("weekly", "monthly")
 #' Weekly and monthly plots are for both variables.

--- a/man/plot_chl_pp.Rd
+++ b/man/plot_chl_pp.Rd
@@ -26,6 +26,8 @@ Weekly and monthly plots are for both variables.}
 
 \item{year}{Numeric value. Optional. Year for weekly plot, defaults to max year in data.}
 
+\item{EPU}{Character string. Which EPU for New England report ("GB", "GOM") Mid will always be MAB}
+
 \item{n}{Numeric scalar. Number of years used (from most recent year) to estimate short term trend . Default = 0 (No trend calculated)}
 }
 \value{


### PR DESCRIPTION
- Refactor `plot_annual_chl_pp`: output carbon in million MT when varName = "pp" and plottype = "total"
- Document `plot_chl_pp`: add missing "EPU" field from function parameters; rebuild documentation to reflect update