### PR TITLE
Minor corrections deployed to plot functions

### DIFF
--- a/R/plot_bottom_temp_model_anom.R
+++ b/R/plot_bottom_temp_model_anom.R
@@ -109,6 +109,9 @@ plot_bottom_temp_model_anom <- function(shadedRegion=NULL,
     #                plot.title = ggplot2::element_text(size = 12))+
     ecodata::theme_title()
 
+  if (plottype == "MOM6") {
+    p <- "The MOM6 plot type is currently unavailable. Please use plottype = 'GLORYS'."
+  }
 
   return(p)
 }
@@ -117,4 +120,4 @@ plot_bottom_temp_model_anom <- function(shadedRegion=NULL,
 attr(plot_bottom_temp_model_anom,"EPU") <- c("MAB","GB","GOM")
 attr(plot_bottom_temp_model_anom,"report") <- c("MidAtlantic","NewEngland")
 attr(plot_bottom_temp_model_anom, "varName") <- c("seasonal", "annual")
-attr(plot_bottom_temp_model_anom, "plottype") <- c("GLORYS", "MOM6")
+attr(plot_bottom_temp_model_anom, "plottype") <- c("GLORYS")

--- a/R/plot_wbts_zoo.R
+++ b/R/plot_wbts_zoo.R
@@ -110,4 +110,4 @@ plot_wbts_zoo <- function(shadedRegion = NULL, report = "NewEngland", n = 0) {
 # plot_wbts_zoo()
 
 attr(plot_wbts_zoo, "report") <- c("NewEngland")
-attr(plot_gsi, "varName") <- c("wbts_zoo")
+attr(plot_wbts_zoo, "varName") <- c("wbts_zoo")


### PR DESCRIPTION
- Correct plot attributes of `plot_wbts_zoo` (Closes #350)
- Change plot behavior of `plot_bottom_temp_model_anom` when using `plottype = "MOM6"` (Closes #349)
- Removed `plottype = "MOM6"` from attributes of `plot_bottom_temp_model_anom` to prevent inclusion in Catalog