### PR TITLE
Remove legend labels for 'Component' and 'Revenue Change'

### DIFF
--- a/R/plot_bennet.R
+++ b/R/plot_bennet.R
@@ -109,6 +109,11 @@ plot_bennet <- function(
       ecodata::theme_ts() +
       ggplot2::scale_fill_brewer(palette = "Set1") +
       ggplot2::theme(title = ggplot2::element_text(size = 10)) +
+      ggplot2::guides(color = "none") +
+      ggplot2::theme(
+        legend.position = "bottom",
+        legend.title = ggplot2::element_blank()
+      ) +
       ecodata::theme_title() +
       ecodata::theme_facet()
   } else if (varName == "total") {
@@ -175,6 +180,11 @@ plot_bennet <- function(
       ecodata::theme_ts() +
       ggplot2::xlab(ggplot2::element_blank()) +
       ggplot2::theme(title = ggplot2::element_text(size = 10)) +
+      ggplot2::guides(color = "none") +
+      ggplot2::theme(
+        legend.position = "bottom",
+        legend.title = ggplot2::element_blank()
+      ) +
       ecodata::theme_title()
   } else if (varName == "total_guild") {
     indicators$Var <- gsub("Predator", "", indicators$Var)
@@ -324,3 +334,4 @@ attr(plot_bennet, "EPU") <- c("MAB", "GB", "GOM")
 #   ecodata::theme_facet()
 #
 #
+


### PR DESCRIPTION
This request came from Internal Review. 

Removed the Revenue Change - $ and Component - $ labels from the total and guild bennet plots by setting guides = 'none'. 

Also moved the legend setting = 'bottom' here instead of in the report generation code. 

Lines 112-116 and 183-187.

Produces these figures:
<img width="750" height="516" alt="guild_GB" src="https://github.com/user-attachments/assets/5ed61395-5395-4ea7-992f-ab24c7f91fd7" />
<img width="750" height="516" alt="guild_GOM" src="https://github.com/user-attachments/assets/d02af852-5ddd-429d-90a7-8c6ee8d3a4f3" />
<img width="750" height="516" alt="guild_MAB" src="https://github.com/user-attachments/assets/3e671e2c-9b49-4498-a1a8-8383405c8e59" />
<img width="550" height="516" alt="total_GB" src="https://github.com/user-attachments/assets/11a1724f-3390-4267-bf16-94cd475c1fb7" />
<img width="651" height="516" alt="total_GOM" src="https://github.com/user-attachments/assets/ede7ab71-01bf-4460-a926-168b95c3d32c" />
<img width="550" height="516" alt="total_MAB" src="https://github.com/user-attachments/assets/68c6f40d-d9e6-48b5-8277-1f0734e3eb11" />
