### PR TITLE
Adding back dashed mean lines to along-shelf and depth figures

### DIFF
--- a/R/plot_species_dist.R
+++ b/R/plot_species_dist.R
@@ -47,7 +47,7 @@ plot_species_dist <- function(
     #dplyr::filter(!Var == "Season") %>%
     dplyr::mutate(Value = as.numeric(Value)) |>
     dplyr::group_by(Var) |>
-    dplyr::mutate(hline = mean(Value)) |>
+    dplyr::mutate(hline = mean(Value, na.rm = TRUE)) |>
     dplyr::ungroup() |>
     dplyr::filter(Var == varName)
 


### PR DESCRIPTION
Hline calcuations were previously resulting in NAs due to missing data years (2020 and 2023). This was causing the dashed mean lines to be removed from the along-shelf and depth figures.

Added na.rm = TRUE to the hline calculation `dplyr::mutate(hline = mean(Value, na.rm = TRUE)) |>` to remove the NA years from the mean.

New figures: 
<img width="651" height="555" alt="along" src="https://github.com/user-attachments/assets/06abe89e-de72-4778-91a2-1e49e58f7e95" />
<img width="651" height="555" alt="depth" src="https://github.com/user-attachments/assets/f1e55792-f13b-4c13-9812-dd993995bdf7" />
