### PR TITLE
Feature(#235): Separate the NE `chl_pp` plots

### DIFF
--- a/R/plot_chl_pp.R
+++ b/R/plot_chl_pp.R
@@ -34,7 +34,10 @@ plot_chl_pp <- function(
   if (report == "MidAtlantic") {
     filterEPUs <- c("MAB")
   } else {
-    filterEPUs <- c("GB", "GOM")
+    if (!(EPU %in% c("GB", "GOM"))) {
+      stop("For NewEngland the epu must be either 'GB' or 'GOM'")
+    }
+    filterEPUs <- EPU
   }
 
   # plot chl and pp
@@ -163,14 +166,13 @@ plot_chl_pp <- function(
         #ecodata::geom_lm(aes(x = Year, y = Value, group = Month))+
         #  ggplot2::geom_point(color = "white") +
         ggplot2::geom_line() +
-        ecodata::geom_lm(n = n)+
-        ecodata::geom_lm(n = 100)+
+        ecodata::geom_lm(n = n) +
+        ecodata::geom_lm(n = 100) +
         ggplot2::scale_x_discrete(breaks = scales::breaks_pretty(n = 3)) +
         ggplot2::facet_grid(
-          rows = ggplot2::vars(EPU),
           cols = ggplot2::vars(Month)
         ) +
-        ggplot2::ggtitle(paste0("Monthly median ", varabbr)) +
+        ggplot2::ggtitle(paste0(EPU, " Monthly median ", varabbr)) +
         ggplot2::ylab(varunits) +
         ggplot2::geom_hline(
           ggplot2::aes(yintercept = hline, group = Month),
@@ -246,9 +248,8 @@ plot_chl_pp <- function(
         #             fill = "grey1") +
         # ggplot2::geom_line(data = ne_pp_late,aes(x = Time, y = Value),
         #           size = 1,color = "#33a02c", linetype = "dashed") +
-        ggplot2::ggtitle(paste(varabbr, titleyear)) +
+        ggplot2::ggtitle(paste(EPU, varabbr, titleyear)) +
         ggplot2::guides(color = "none") +
-        ggplot2::facet_wrap(EPU ~ ., ncol = 2) +
         ggplot2::xlab("") +
         ggplot2::ylab(varunits) +
         ggplot2::scale_x_continuous(


### PR DESCRIPTION
### Justification
The faceted NE plots from `plot_chl_pp` do not work well in _ecodata_ or Catalog because they are difficult to read and are duplicative. Kim requested a review to see if the NE plots could be separated by EPU. After implementing and testing the change, the plot function does perform better across products when separated. 
Fixes #235 

### Types of changes
What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [x] Feature (non-breaking change which adds or changes functionality)

### Further comments
The reports are the only products where faceting these plots makes sense. As such, report code calling `ecodata::plot_chl_pp(report = "NewEngland", ...` needs to re-facet the outputs for `..., EPU = "GB"` and `..., EPU = "GOM"`. Please also note that we _will not_ increment the _ecodata_ version despite this being a feature change. We will implement proper Semantic Versioning after the next package release.

### Reviewer instructions:
Please build `ecodata@feature/i235-separate-chl_pp-plots` and check all plots from the `ecodata::plot_chl_pp()`. The easiest way to do this is running: `ecodata::create_all_plots(ecodata_name = "chl_pp", n = 0)`. Ensure all plots work and look correct.

### Formatting
This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [air](https://posit-dev.github.io/air/) formatting tool.