### PR TITLE
Refactor(#392): Add dynamic `n` argument to `plot_chl_pp`

### DIFF
--- a/R/plot_chl_pp.R
+++ b/R/plot_chl_pp.R
@@ -167,7 +167,7 @@ plot_chl_pp <- function(
         #  ggplot2::geom_point(color = "white") +
         ggplot2::geom_line() +
         ecodata::geom_lm(n = n) +
-        ecodata::geom_lm(n = 100) +
+        ecodata::geom_lm(n = length(unique(out$Year))) +
         ggplot2::scale_x_discrete(breaks = scales::breaks_pretty(n = 3)) +
         ggplot2::facet_grid(
           cols = ggplot2::vars(Month)


### PR DESCRIPTION
### Justification
The plot function for `chl_pp` contained a hard-coded argument for the short term trend (`n = 100`). This has been replaced by code which dynamically sets `n` to the length of the time series, which is a better standard to follow.
Fixes #392 

### Types of changes
What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [x] Other change (if none of the other choices apply)

### Reviewer instructions:
Please build `ecodata@refactor/i392-dynamic-short-trend` and check all plots from the `ecodata::plot_chl_pp()`. The easiest way to do this is running: `ecodata::create_all_plots(ecodata_name = "chl_pp", n = 0)`. Ensure all plots work and look correct.

### Formatting
This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [air](https://posit-dev.github.io/air/) formatting tool.