### PR TITLE
Fix(#396): Minor plot fixes

### DIFF
--- a/R/plot_SAV.R
+++ b/R/plot_SAV.R
@@ -89,7 +89,7 @@ plot_SAV <- function(shadedRegion = NULL, report = "MidAtlantic", n = 0) {
 }
 
 
-attr(plot_SAV, "report") <- c("MidAtlantic", "NewEngland")
+attr(plot_SAV, "report") <- c("MidAtlantic")
 
 # Paste commented original plot code chunk for reference
 # ecodata::SAV %>%

--- a/R/plot_ch_bay_sal.R
+++ b/R/plot_ch_bay_sal.R
@@ -66,7 +66,7 @@ plot_ch_bay_sal <- function(shadedRegion = NULL, report = "MidAtlantic") {
   return(p)
 }
 
-attr(plot_ch_bay_sal, "report") <- c("MidAtlantic", "NewEngland")
+attr(plot_ch_bay_sal, "report") <- c("MidAtlantic")
 
 # Paste commented original plot code chunk for reference
 # MAB only

--- a/R/plot_ch_bay_temp.R
+++ b/R/plot_ch_bay_temp.R
@@ -77,7 +77,7 @@ plot_ch_bay_temp <- function(shadedRegion = NULL, report = "MidAtlantic") {
 }
 
 
-attr(plot_ch_bay_temp, "report") <- c("MidAtlantic", "NewEngland")
+attr(plot_ch_bay_temp, "report") <- c("MidAtlantic")
 
 # Paste commented original plot code chunk for reference
 # MAB only

--- a/R/plot_ches_bay_wq.R
+++ b/R/plot_ches_bay_wq.R
@@ -60,9 +60,11 @@ plot_ches_bay_wq <- function(
     ecodata::geom_gls() +
     ecodata::geom_lm(n = n) +
     #ecodata::geom_lm()+
-    ggplot2::ylab(expression("Estimated attainment (%)")) +
-    ggplot2::xlab(ggplot2::element_blank()) +
-    ggplot2::ggtitle("Chesapeake Bay Water Quality Attainment") +
+    ggplot2::labs(
+      x = "Assessment Period",
+      y = "Estimated attainment (%)",
+      title = "Chesapeake Bay Water Quality Attainment"
+    ) +
     ggplot2::scale_x_continuous(
       breaks = minlab,
       labels = c("87-89", "92-94", "97-99", "02-04", "07-09", "12-14", "17-19")

--- a/R/plot_ches_bay_wq.R
+++ b/R/plot_ches_bay_wq.R
@@ -87,7 +87,7 @@ plot_ches_bay_wq <- function(
   return(p)
 }
 
-attr(plot_ches_bay_wq, "report") <- c("MidAtlantic", "NewEngland")
+attr(plot_ches_bay_wq, "report") <- c("MidAtlantic")
 
 # Paste commented original plot code chunk for reference
 # minlab <- seq(1987,2017,5)

--- a/R/plot_cold_pool.R
+++ b/R/plot_cold_pool.R
@@ -264,7 +264,7 @@ plot_cold_pool <- function(
   return(p)
 }
 
-attr(plot_cold_pool, "report") <- c("MidAtlantic", "NewEngland")
+attr(plot_cold_pool, "report") <- c("MidAtlantic")
 attr(plot_cold_pool, "varName") <- c("cold_pool", "persistence", "extent")
 #attr(plot_cold_pool, "source") <- c("GLORYS", "MOM6")
 

--- a/R/plot_gom_salmon.R
+++ b/R/plot_gom_salmon.R
@@ -72,4 +72,4 @@ plot_gom_salmon <- function(shadedRegion = NULL, report = "NewEngland", n = 0) {
   return(p)
 }
 
-attr(plot_gom_salmon, "report") <- c("MidAtlantic", "NewEngland")
+attr(plot_gom_salmon, "report") <- c("MidAtlantic")

--- a/R/plot_grayseal.R
+++ b/R/plot_grayseal.R
@@ -87,7 +87,7 @@ plot_grayseal <- function(shadedRegion = NULL, report = "MidAtlantic") {
   return(p)
 }
 
-attr(plot_grayseal, "report") <- c("MidAtlantic", "NewEngland")
+attr(plot_grayseal, "report") <- c("MidAtlantic")
 # Paste commented original plot code chunk for reference
 # ribbon<- ecodata::grayseal %>%
 #   tidyr::pivot_wider(names_from = Var, values_from = Value)

--- a/R/plot_hms_landings.R
+++ b/R/plot_hms_landings.R
@@ -71,6 +71,9 @@ plot_hms_landings <- function(
     ) +
     ggplot2::ylab(ylabdat) +
     ggplot2::xlab("Time") +
+    ggplot2::scale_x_continuous(
+      breaks = seq(min(apex$Time), max(apex$Time), by = 2)
+    ) +
     ggplot2::ggtitle(paste("HMS", setup$region, "Commercial", varName)) +
     ecodata::theme_title()
 

--- a/R/plot_long_term_sst.R
+++ b/R/plot_long_term_sst.R
@@ -61,4 +61,4 @@ plot_long_term_sst <- function(
   return(p)
 }
 
-attr(plot_long_term_sst, "report") <- c("MidAtlantic", "NewEngland")
+attr(plot_long_term_sst, "report") <- c("MidAtlantic")

--- a/R/plot_seal_pups.R
+++ b/R/plot_seal_pups.R
@@ -75,4 +75,4 @@ plot_seal_pups <- function(shadedRegion = NULL, report = "MidAtlantic") {
 }
 
 
-attr(plot_seal_pups, "report") <- c("MidAtlantic", "NewEngland")
+attr(plot_seal_pups, "report") <- c("MidAtlantic")


### PR DESCRIPTION
### Justification
While reviewing Catalog, identified duplicate plots and incorrect axes and titles. Some changes here are minor revisions to plot titles and axes, but the bulk of them are the removal of the 'NewEngland' report attribute to prevent plot duplication. This is not every plot which is duplicated. Some will require more nuanced reworks to navigate the various argument combinations. These are the obvious and immediately resolvable fixes which can make it in before this SOE cycle is finalized.
Fixes #396 

### Types of changes
What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [x] Fix (non-breaking change which fixes a bug)

### Further comments
Please note that we _will not_ increment the _ecodata_ version despite this being a fix. We will implement proper Semantic Versioning after the next package release.

### Reviewer instructions:
To review, please review the commits and changed files. This should identify how minor most of these changes are. If desired, all plot functions changed here (see changed files for list) may be tested using `ecodata::create_all_plots()`. This would be the ideal approach, but given the trivial nature of almost all changes here, it is not necessary.

### Formatting
This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [air](https://posit-dev.github.io/air/) formatting tool.